### PR TITLE
Fix requirements install issues

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,10 @@
+ENVIRONMENT=test
+DB_HOST=localhost
+DB_PORT=5433
+DB_USER=test_user
+DB_PASSWORD=test_password
+DB_NAME=defaultdb_test
+DB_SSL_MODE=prefer
+FIREBASE_SERVICE_ACCOUNT_KEY_PATH=service-account.json
+SENTRY_DSN=
+DB_CA_CERT_FILE=

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ email-validator # Required by pydantic's EmailStr
 pytest
 httpx
 pytest-asyncio
+PyYAML==6.0


### PR DESCRIPTION
## Summary
- pin PyYAML to avoid build failures
- add sample `.env.test` file for pytest-dotenv

## Testing
- `pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68727f78a0a88332922060fba661a0df